### PR TITLE
test: publish @kittycorn-labs SDKs to npm

### DIFF
--- a/sdks/permit2-sdk/package.json
+++ b/sdks/permit2-sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniswap/permit2-sdk",
   "version": "1.0.0",
+  "private": true,
   "description": "An sdk for interacting with permit2.",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/router-sdk/CHANGELOG.md
+++ b/sdks/router-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kittycorn-labs/router-sdk
 
+## 1.2.30
+
+### Patch Changes
+
+- test publish @kittycorn-labs/router-sdk
+
 ## 1.2.29
 
 ### Patch Changes

--- a/sdks/router-sdk/package.json
+++ b/sdks/router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycorn-labs/router-sdk",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
   "repository": "https://github.com/Crown-Labs/sdks.git",
   "keywords": [

--- a/sdks/smart-wallet-sdk/package.json
+++ b/sdks/smart-wallet-sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniswap/smart-wallet-sdk",
   "version": "1.0.0",
+  "private": true,
   "description": "⚒️ An SDK for building applications with smart wallets on Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -1,6 +1,7 @@
 {
   "name": "uniswapx-integration",
   "version": "0.1.0",
+  "private": true,
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdks/uniswapx-sdk/package.json
+++ b/sdks/uniswapx-sdk/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@uniswap/uniswapx-sdk",
   "version": "1.0.0",
+  "private": true,
   "author": "Uniswap",
   "repository": "https://github.com/Uniswap/sdks.git",
   "keywords": [

--- a/sdks/universal-router-sdk/CHANGELOG.md
+++ b/sdks/universal-router-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @kittycorn-labs/universal-router-sdk
 
+## 1.4.41
+
+### Patch Changes
+
+- Updated dependencies
+  - @kittycorn-labs/router-sdk@1.2.30
+
 ## 1.4.40
 
 ### Patch Changes

--- a/sdks/universal-router-sdk/package.json
+++ b/sdks/universal-router-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kittycorn-labs/universal-router-sdk",
-  "version": "1.4.40",
+  "version": "1.4.41",
   "description": "sdk for integrating with the Universal Router contracts",
   "repository": "https://github.com/Crown-Labs/sdks",
   "keywords": [


### PR DESCRIPTION
## Summary
- Test publishing all @kittycorn-labs SDK packages to npm
- Marked legacy @uniswap packages as private to prevent publishing
- Verify changeset release workflow and npm provenance

## Changes
- Updated package versions for all @kittycorn-labs SDKs
- Set `private: true` for legacy packages:
  - @uniswap/uniswapx-sdk
  - @uniswap/permit2-sdk
  - @uniswap/smart-wallet-sdk
  - uniswapx-integration

## Test plan
- [ ] All packages build successfully with `yarn g:build`
- [ ] All tests pass with `yarn g:test`
- [ ] Linting passes with `yarn g:lint`
- [ ] Changeset version bumps are correct
- [ ] NPM publish with provenance succeeds for @kittycorn-labs packages
- [ ] Legacy @uniswap packages are NOT published
- [ ] Published packages are accessible on npm registry
- [ ] Package dependencies resolve correctly